### PR TITLE
Make it more explicit that composer needs to be installed

### DIFF
--- a/php/README.md
+++ b/php/README.md
@@ -2,6 +2,8 @@
 
 This example uses https://github.com/Lusitanian/PHPoAuthLib to make the OAuth requests.
 
+The PHP dependencies are installed using [Composer](https://getcomposer.org/). You will either need to install composer yourself, or you can use the Vagrant VM provided which will automatically setup a test environment with composer installed for you. See the main [README.md](../README.md) file for more information on this.
+
 To run the example, edit the ResDiaryOAuthExample.php file to the API URLs and your credentials:
 
 ```php


### PR DESCRIPTION
It wasn't completely obvious from the README that composer needs to be installed before you can run the `composer install` command. I've updated it to make it clearer.